### PR TITLE
Feature: Add weapon ammo display to ESP overlay

### DIFF
--- a/controller/src/enhancements/player/mod.rs
+++ b/controller/src/enhancements/player/mod.rs
@@ -10,6 +10,7 @@ use cs2::{
     StateLocalPlayerController,
     StatePawnInfo,
     StatePawnModelInfo,
+    WeaponId,
 };
 use info_layout::PlayerInfoLayout;
 use obfstr::obfstr;
@@ -474,7 +475,7 @@ impl Enhancement for PlayerESP {
                     );
                 }
 
-                if esp_settings.info_ammo {
+                if esp_settings.info_ammo && pawn_info.weapon != WeaponId::Knife {
                     let text = format!(
                         "{}/{}",
                         pawn_info.weapon_current_ammo, pawn_info.weapon_reserve_ammo

--- a/controller/src/enhancements/player/mod.rs
+++ b/controller/src/enhancements/player/mod.rs
@@ -10,7 +10,6 @@ use cs2::{
     StateLocalPlayerController,
     StatePawnInfo,
     StatePawnModelInfo,
-    WeaponId,
 };
 use info_layout::PlayerInfoLayout;
 use obfstr::obfstr;
@@ -475,7 +474,7 @@ impl Enhancement for PlayerESP {
                     );
                 }
 
-                if esp_settings.info_ammo && pawn_info.weapon != WeaponId::Knife {
+                if esp_settings.info_ammo && pawn_info.weapon_current_ammo != -1 {
                     let text = format!(
                         "{}/{}",
                         pawn_info.weapon_current_ammo, pawn_info.weapon_reserve_ammo

--- a/controller/src/enhancements/player/mod.rs
+++ b/controller/src/enhancements/player/mod.rs
@@ -474,6 +474,19 @@ impl Enhancement for PlayerESP {
                     );
                 }
 
+                if esp_settings.info_ammo {
+                    let text = format!(
+                        "{}/{}",
+                        pawn_info.weapon_current_ammo, pawn_info.weapon_reserve_ammo
+                    );
+                    player_info.add_line(
+                        esp_settings
+                            .info_ammo_color
+                            .calculate_color(player_rel_health, distance),
+                        &text,
+                    );
+                }
+
                 if esp_settings.info_hp_text {
                     let text = format!("{} HP", pawn_info.player_health);
                     player_info.add_line(

--- a/controller/src/settings/esp.rs
+++ b/controller/src/settings/esp.rs
@@ -362,6 +362,9 @@ impl Default for EspPlayerSettings {
             info_weapon: false,
             info_weapon_color: neutral_color,
 
+            info_ammo: false,
+            info_ammo_color: neutral_color,
+
             info_flag_kit: false,
             info_flag_flashed: false,
             info_flags_color: neutral_color,

--- a/controller/src/settings/esp.rs
+++ b/controller/src/settings/esp.rs
@@ -235,6 +235,9 @@ pub struct EspPlayerSettings {
     pub info_weapon: bool,
     pub info_weapon_color: EspColor,
 
+    pub info_ammo: bool,
+    pub info_ammo_color: EspColor,
+
     pub info_hp_text: bool,
     pub info_hp_text_color: EspColor,
 
@@ -304,6 +307,9 @@ impl EspPlayerSettings {
 
             info_weapon: false,
             info_weapon_color: color.clone(),
+
+            info_ammo: false,
+            info_ammo_color: color.clone(),
 
             info_flag_kit: false,
             info_flag_flashed: false,

--- a/controller/src/settings/ui.rs
+++ b/controller/src/settings/ui.rs
@@ -604,6 +604,7 @@ impl SettingsUI {
                 ui.text("Player Info");
                 ui.checkbox(obfstr!("Name"), &mut config.info_name);
                 ui.checkbox(obfstr!("Weapon"), &mut config.info_weapon);
+                ui.checkbox(obfstr!("Ammo"), &mut config.info_ammo);
                 ui.checkbox(obfstr!("Distance"), &mut config.info_distance);
                 ui.checkbox(obfstr!("Health"), &mut config.info_hp_text);
                 ui.checkbox(obfstr!("Kit"), &mut config.info_flag_kit);
@@ -762,6 +763,13 @@ impl SettingsUI {
                         ui,
                         obfstr!("Color info weapon"),
                         &mut config.info_weapon_color,
+                    );
+
+                    ui.table_next_row();
+                    Self::render_esp_settings_player_style_color(
+                        ui,
+                        obfstr!("Color info ammo"),
+                        &mut config.info_ammo_color,
                     );
 
                     ui.table_next_row();

--- a/cs2/src/state/player.rs
+++ b/cs2/src/state/player.rs
@@ -16,6 +16,7 @@ use cs2_schema_generated::cs2::client::{
     CSkeletonInstance,
     C_BaseEntity,
     C_BasePlayerPawn,
+    C_BasePlayerWeapon,
     C_CSPlayerPawn,
     C_CSPlayerPawnBase,
     C_EconEntity,
@@ -47,6 +48,8 @@ pub struct StatePawnInfo {
     pub player_has_defuser: bool,
     pub player_name: Option<String>,
     pub weapon: WeaponId,
+    pub weapon_current_ammo: i32,
+    pub weapon_reserve_ammo: i32,
     pub player_flashtime: f32,
 
     pub player_has_flash: u32,
@@ -152,16 +155,25 @@ impl State for StatePawnInfo {
         let position =
             nalgebra::Vector3::<f32>::from_column_slice(&game_screen_node.m_vecAbsOrigin()?);
 
-        let weapon = player_pawn
+        let weapon_ref = player_pawn
             .m_pClippingWeapon()?
             .value_reference(memory.view_arc());
-        let weapon_type = if let Some(weapon) = weapon {
+        let weapon_type = if let Some(weapon) = &weapon_ref {
             weapon
                 .m_AttributeManager()?
                 .m_Item()?
                 .m_iItemDefinitionIndex()?
         } else {
             WeaponId::Knife.id()
+        };
+
+        let (weapon_current_ammo, weapon_reserve_ammo) = if weapon_type == WeaponId::Knife.id() {
+            (0, 0)
+        } else if let Some(weapon) = weapon_ref.as_ref() {
+            let weapon = weapon.cast::<dyn C_BasePlayerWeapon>();
+            (weapon.m_iClip1()?, weapon.m_pReserveAmmo()?[0])
+        } else {
+            (0, 0)
         };
 
         let player_flashtime = player_pawn.m_flFlashBangTime()?;
@@ -180,6 +192,8 @@ impl State for StatePawnInfo {
             player_has_defuser,
             player_health,
             weapon: WeaponId::from_id(weapon_type).unwrap_or(WeaponId::Unknown),
+            weapon_current_ammo,
+            weapon_reserve_ammo,
             player_flashtime,
 
             player_has_flash,

--- a/cs2/src/state/player.rs
+++ b/cs2/src/state/player.rs
@@ -167,13 +167,11 @@ impl State for StatePawnInfo {
             WeaponId::Knife.id()
         };
 
-        let (weapon_current_ammo, weapon_reserve_ammo) = if weapon_type == WeaponId::Knife.id() {
-            (0, 0)
-        } else if let Some(weapon) = weapon_ref.as_ref() {
+        let (weapon_current_ammo, weapon_reserve_ammo) = if let Some(weapon) = weapon_ref.as_ref() {
             let weapon = weapon.cast::<dyn C_BasePlayerWeapon>();
             (weapon.m_iClip1()?, weapon.m_pReserveAmmo()?[0])
         } else {
-            (0, 0)
+            (-1, 0)
         };
 
         let player_flashtime = player_pawn.m_flFlashBangTime()?;


### PR DESCRIPTION
Add ammo display functionality to ESP overlay showing current/reserve ammo (e.g. "30/90")

Preview:
![image](https://github.com/user-attachments/assets/5ec84086-a50e-4b68-bb07-d31d9dd74636)

### Testing
The changes have been tested with:
- Different weapon types
- Non-Ammo weapons (not show in display)
- Various ammunition states
- ESP color customization
