### PR TITLE
Feature: Add Bomb Carrier to ESP

### DIFF
--- a/controller/src/enhancements/bomb.rs
+++ b/controller/src/enhancements/bomb.rs
@@ -1,22 +1,6 @@
-use anyhow::Context;
 use cs2::{
-    state::{
-        PlantedC4,
-        StatePawnInfo,
-    },
-    CEntityIdentityEx,
-    ClassNameCache,
-    LocalCameraControllerTarget,
+    state::PlantedC4,
     PlantedC4State,
-    StateCS2Memory,
-    StateEntityList,
-};
-use cs2_schema_cutl::EntityHandle;
-use cs2_schema_generated::cs2::client::{
-    CBasePlayerController,
-    C_CSObserverPawn,
-    C_CSPlayerPawn,
-    C_CSPlayerPawnBase,
 };
 use imgui::ImColor32;
 use overlay::UnicodeTextRenderer;
@@ -35,62 +19,6 @@ impl BombInfoIndicator {
     pub fn new() -> Self {
         Self {}
     }
-
-    fn get_view_pawn_info(
-        &self,
-        states: &utils_state::StateRegistry,
-        memory: &StateCS2Memory,
-        entities: &StateEntityList,
-        class_name_cache: &ClassNameCache,
-        target_entity_id: u32,
-    ) -> anyhow::Result<Option<StatePawnInfo>> {
-        let entity_identity = entities
-            .identity_from_index(target_entity_id)
-            .context("missing entity identity")?;
-
-        let entity_class = class_name_cache
-            .lookup(&entity_identity.entity_class_info()?)?
-            .context("failed to resolve entity class")?;
-
-        let pawn_identity = match entity_class.as_str() {
-            "C_CSPlayerPawn" => Some(entity_identity),
-            "C_CSObserverPawn" => {
-                let observer_pawn = entity_identity
-                    .entity_ptr::<dyn C_CSObserverPawn>()?
-                    .value_reference(memory.view_arc())
-                    .context("observer pawn nullptr")?;
-
-                let controller_handle = observer_pawn.m_hOriginalController()?;
-
-                let player_controller = entities
-                    .entity_from_handle(&controller_handle)
-                    .context("missing observer controller")?
-                    .value_reference(memory.view_arc())
-                    .context("nullptr")?
-                    .cast::<dyn CBasePlayerController>();
-
-                let pawn_handle = player_controller.m_hPawn()?;
-
-                entities.identity_from_index(pawn_handle.value & 0x7FFF)
-            }
-            _ => None,
-        };
-
-        if let Some(pawn_identity) = pawn_identity {
-            // Get the handle and then the entity index from it
-            let handle = pawn_identity.handle::<()>()?;
-            let entity_index = handle.get_entity_index();
-
-            // Create a C_CSPlayerPawn EntityHandle from the entity index
-            let pawn_handle = EntityHandle::<dyn C_CSPlayerPawn>::from_index(entity_index);
-
-            states
-                .resolve::<StatePawnInfo>(pawn_handle)
-                .map(|pawn_info| Some(pawn_info.clone()))
-        } else {
-            Ok(None)
-        }
-    }
 }
 
 /// % of the screens height
@@ -98,9 +26,6 @@ const PLAYER_AVATAR_TOP_OFFSET: f32 = 0.004;
 
 /// % of the screens height
 const PLAYER_AVATAR_SIZE: f32 = 0.05;
-
-/// Maximum distance to be damaged by bomb
-pub const MAX_DAMAGE_RANGE: f32 = 1768.0;
 
 impl Enhancement for BombInfoIndicator {
     fn update(&mut self, _ctx: &crate::UpdateContext) -> anyhow::Result<()> {
@@ -115,16 +40,6 @@ impl Enhancement for BombInfoIndicator {
     ) -> anyhow::Result<()> {
         let settings = states.resolve::<AppSettings>(())?;
         let bomb_state = states.resolve::<PlantedC4>(())?;
-        let memory = states.resolve::<StateCS2Memory>(())?;
-        let view_target = states.resolve::<LocalCameraControllerTarget>(())?;
-        let entities = states.resolve::<StateEntityList>(())?;
-        let class_name_cache = states.resolve::<ClassNameCache>(())?;
-
-        // Get the current target entity ID (whether local player or being spectated)
-        let target_entity_id = match view_target.target_entity_id {
-            Some(id) => id,
-            None => return Ok(()),
-        };
 
         if !settings.bomb_timer {
             return Ok(());
@@ -194,39 +109,6 @@ impl Enhancement for BombInfoIndicator {
                 ui.text_with_shadow("Bomb has been detonated");
             }
             PlantedC4State::NotPlanted => unreachable!(),
-        }
-
-        if let PlantedC4State::Active { .. } = &bomb_state.state {
-            if let Some(pawn_info) = self.get_view_pawn_info(
-                states,
-                &memory,
-                &entities,
-                &class_name_cache,
-                target_entity_id,
-            )? {
-                let distance = (pawn_info.position - bomb_state.position).magnitude();
-
-                // Damage formula from CS:GO, likely similar in CS2.
-                let damage = if distance > MAX_DAMAGE_RANGE {
-                    0.0
-                } else {
-                    // Damage = 500 * e^(-distance_in_units / 500)
-                    500.0 * (-distance / 500.0).exp()
-                };
-
-                let is_safe = (damage as i32) < pawn_info.player_health;
-
-                let (safety_text, safety_color) = if is_safe {
-                    ("You're safe!", ImColor32::from_rgba(28, 201, 66, 255))
-                } else {
-                    ("You're not safe!", ImColor32::from_rgba(201, 28, 28, 255))
-                };
-
-                offset_y += ui.text_line_height_with_spacing();
-
-                ui.set_cursor_pos([offset_x, offset_y]);
-                ui.unicode_text_colored_with_shadow(unicode_text, safety_color, safety_text);
-            }
         }
 
         group.end();

--- a/controller/src/enhancements/bomb.rs
+++ b/controller/src/enhancements/bomb.rs
@@ -1,6 +1,22 @@
+use anyhow::Context;
 use cs2::{
-    PlantedC4,
+    state::{
+        PlantedC4,
+        StatePawnInfo,
+    },
+    CEntityIdentityEx,
+    ClassNameCache,
+    LocalCameraControllerTarget,
     PlantedC4State,
+    StateCS2Memory,
+    StateEntityList,
+};
+use cs2_schema_cutl::EntityHandle;
+use cs2_schema_generated::cs2::client::{
+    CBasePlayerController,
+    C_CSObserverPawn,
+    C_CSPlayerPawn,
+    C_CSPlayerPawnBase,
 };
 use imgui::ImColor32;
 use overlay::UnicodeTextRenderer;
@@ -13,11 +29,67 @@ use crate::{
         UnicodeTextWithShadowUi,
     },
 };
-pub struct BombInfoIndicator {}
 
+pub struct BombInfoIndicator {}
 impl BombInfoIndicator {
     pub fn new() -> Self {
         Self {}
+    }
+
+    fn get_view_pawn_info(
+        &self,
+        states: &utils_state::StateRegistry,
+        memory: &StateCS2Memory,
+        entities: &StateEntityList,
+        class_name_cache: &ClassNameCache,
+        target_entity_id: u32,
+    ) -> anyhow::Result<Option<StatePawnInfo>> {
+        let entity_identity = entities
+            .identity_from_index(target_entity_id)
+            .context("missing entity identity")?;
+
+        let entity_class = class_name_cache
+            .lookup(&entity_identity.entity_class_info()?)?
+            .context("failed to resolve entity class")?;
+
+        let pawn_identity = match entity_class.as_str() {
+            "C_CSPlayerPawn" => Some(entity_identity),
+            "C_CSObserverPawn" => {
+                let observer_pawn = entity_identity
+                    .entity_ptr::<dyn C_CSObserverPawn>()?
+                    .value_reference(memory.view_arc())
+                    .context("observer pawn nullptr")?;
+
+                let controller_handle = observer_pawn.m_hOriginalController()?;
+
+                let player_controller = entities
+                    .entity_from_handle(&controller_handle)
+                    .context("missing observer controller")?
+                    .value_reference(memory.view_arc())
+                    .context("nullptr")?
+                    .cast::<dyn CBasePlayerController>();
+
+                let pawn_handle = player_controller.m_hPawn()?;
+
+                entities.identity_from_index(pawn_handle.value & 0x7FFF)
+            }
+            _ => None,
+        };
+
+        if let Some(pawn_identity) = pawn_identity {
+            // Get the handle and then the entity index from it
+            let handle = pawn_identity.handle::<()>()?;
+            let entity_index = handle.get_entity_index();
+
+            // Create a C_CSPlayerPawn EntityHandle from the entity index
+            let pawn_handle = EntityHandle::<dyn C_CSPlayerPawn>::from_index(entity_index);
+
+            states
+                .resolve::<StatePawnInfo>(pawn_handle)
+                .map(|pawn_info| Some(pawn_info.clone()))
+        } else {
+            Ok(None)
+        }
     }
 }
 
@@ -26,6 +98,9 @@ const PLAYER_AVATAR_TOP_OFFSET: f32 = 0.004;
 
 /// % of the screens height
 const PLAYER_AVATAR_SIZE: f32 = 0.05;
+
+/// Maximum distance to be damaged by bomb
+pub const MAX_DAMAGE_RANGE: f32 = 1768.0;
 
 impl Enhancement for BombInfoIndicator {
     fn update(&mut self, _ctx: &crate::UpdateContext) -> anyhow::Result<()> {
@@ -39,11 +114,22 @@ impl Enhancement for BombInfoIndicator {
         unicode_text: &UnicodeTextRenderer,
     ) -> anyhow::Result<()> {
         let settings = states.resolve::<AppSettings>(())?;
+        let bomb_state = states.resolve::<PlantedC4>(())?;
+        let memory = states.resolve::<StateCS2Memory>(())?;
+        let view_target = states.resolve::<LocalCameraControllerTarget>(())?;
+        let entities = states.resolve::<StateEntityList>(())?;
+        let class_name_cache = states.resolve::<ClassNameCache>(())?;
+
+        // Get the current target entity ID (whether local player or being spectated)
+        let target_entity_id = match view_target.target_entity_id {
+            Some(id) => id,
+            None => return Ok(()),
+        };
+
         if !settings.bomb_timer {
             return Ok(());
         }
 
-        let bomb_state = states.resolve::<PlantedC4>(())?;
         if matches!(bomb_state.state, PlantedC4State::NotPlanted) {
             return Ok(());
         }
@@ -108,6 +194,39 @@ impl Enhancement for BombInfoIndicator {
                 ui.text_with_shadow("Bomb has been detonated");
             }
             PlantedC4State::NotPlanted => unreachable!(),
+        }
+
+        if let PlantedC4State::Active { .. } = &bomb_state.state {
+            if let Some(pawn_info) = self.get_view_pawn_info(
+                states,
+                &memory,
+                &entities,
+                &class_name_cache,
+                target_entity_id,
+            )? {
+                let distance = (pawn_info.position - bomb_state.position).magnitude();
+
+                // Damage formula from CS:GO, likely similar in CS2.
+                let damage = if distance > MAX_DAMAGE_RANGE {
+                    0.0
+                } else {
+                    // Damage = 500 * e^(-distance_in_units / 500)
+                    500.0 * (-distance / 500.0).exp()
+                };
+
+                let is_safe = (damage as i32) < pawn_info.player_health;
+
+                let (safety_text, safety_color) = if is_safe {
+                    ("You're safe!", ImColor32::from_rgba(28, 201, 66, 255))
+                } else {
+                    ("You're not safe!", ImColor32::from_rgba(201, 28, 28, 255))
+                };
+
+                offset_y += ui.text_line_height_with_spacing();
+
+                ui.set_cursor_pos([offset_x, offset_y]);
+                ui.unicode_text_colored_with_shadow(unicode_text, safety_color, safety_text);
+            }
         }
 
         group.end();

--- a/controller/src/enhancements/player/mod.rs
+++ b/controller/src/enhancements/player/mod.rs
@@ -520,6 +520,10 @@ impl Enhancement for PlayerESP {
                     player_flags.push("Kit");
                 }
 
+                if esp_settings.info_flag_bomb && pawn_info.player_has_bomb {
+                    player_flags.push("Bomb Carrier");
+                }
+
                 if esp_settings.info_flag_flashed && pawn_info.player_flashtime > 0.0 {
                     player_flags.push("flashed");
                 }

--- a/controller/src/settings/esp.rs
+++ b/controller/src/settings/esp.rs
@@ -240,6 +240,7 @@ pub struct EspPlayerSettings {
 
     pub info_flag_kit: bool,
     pub info_flag_flashed: bool,
+    pub info_flag_bomb: bool,
     pub info_flags_color: EspColor,
 
     pub info_grenades: bool,
@@ -307,6 +308,7 @@ impl EspPlayerSettings {
 
             info_flag_kit: false,
             info_flag_flashed: false,
+            info_flag_bomb: false,
             info_flags_color: color.clone(),
 
             info_grenades: false,

--- a/controller/src/settings/esp.rs
+++ b/controller/src/settings/esp.rs
@@ -360,6 +360,7 @@ impl Default for EspPlayerSettings {
 
             info_flag_kit: false,
             info_flag_flashed: false,
+            info_flag_bomb: false,
             info_flags_color: neutral_color,
 
             info_grenades: false,

--- a/controller/src/settings/ui.rs
+++ b/controller/src/settings/ui.rs
@@ -608,6 +608,7 @@ impl SettingsUI {
                 ui.checkbox(obfstr!("Health"), &mut config.info_hp_text);
                 ui.checkbox(obfstr!("Kit"), &mut config.info_flag_kit);
                 ui.checkbox(obfstr!("Flashed"), &mut config.info_flag_flashed);
+                ui.checkbox(obfstr!("Bomb Carrier"), &mut config.info_flag_bomb);
                 ui.checkbox(obfstr!("Grenades"), &mut config.info_grenades);
                 ui.checkbox(obfstr!("Near only"), &mut config.near_players);
                 if config.near_players {

--- a/cs2/src/lib.rs
+++ b/cs2/src/lib.rs
@@ -9,7 +9,7 @@ pub mod schema;
 mod offsets;
 pub use offsets::*;
 
-mod state;
+pub mod state;
 pub use state::*;
 
 mod entity;

--- a/cs2/src/state/bomb.rs
+++ b/cs2/src/state/bomb.rs
@@ -2,9 +2,11 @@ use std::ffi::CStr;
 
 use anyhow::Context;
 use cs2_schema_generated::cs2::client::{
+    C_BaseEntity,
     C_BasePlayerPawn,
     C_PlantedC4,
 };
+use nalgebra::Vector3;
 use obfstr::obfstr;
 use utils_state::{
     State,
@@ -57,6 +59,9 @@ pub struct PlantedC4 {
     /// Current state of the planted C4
     pub state: PlantedC4State,
 
+    /// Position of the planted bomb.
+    pub position: Vector3<f32>,
+
     /// Current bomb defuser
     pub defuser: Option<BombDefuser>,
 }
@@ -88,6 +93,17 @@ impl State for PlantedC4 {
                 .value_copy(memory.view())?
                 .context("bomb entity nullptr")?;
 
+            let game_scene_node = entity_identity
+                .entity_ptr::<dyn C_BaseEntity>()?
+                .value_reference(memory.view_arc())
+                .context("C_BaseEntity pointer was null")?
+                .m_pGameSceneNode()?
+                .value_reference(memory.view_arc())
+                .context("m_pGameSceneNode pointer was null")?
+                .copy()?;
+
+            let position = game_scene_node.m_vecAbsOrigin()?;
+
             if !bomb.m_bC4Activated()? {
                 /* This bomb hasn't been activated (yet) */
                 continue;
@@ -97,6 +113,7 @@ impl State for PlantedC4 {
             if bomb.m_bBombDefused()? {
                 return Ok(Self {
                     bomb_site,
+                    position: position.into(),
                     defuser: None,
                     state: PlantedC4State::Defused,
                 });
@@ -107,6 +124,7 @@ impl State for PlantedC4 {
             if time_blow <= globals.time_2()? {
                 return Ok(Self {
                     bomb_site,
+                    position: position.into(),
                     defuser: None,
                     state: PlantedC4State::Detonated,
                 });
@@ -148,6 +166,7 @@ impl State for PlantedC4 {
             return Ok(Self {
                 bomb_site,
                 defuser: defusing,
+                position: position.into(),
                 state: PlantedC4State::Active {
                     time_detonation: time_blow - globals.time_2()?,
                 },
@@ -157,6 +176,7 @@ impl State for PlantedC4 {
         return Ok(Self {
             bomb_site: 0,
             defuser: None,
+            position: Default::default(),
             state: PlantedC4State::NotPlanted,
         });
     }

--- a/cs2/src/state/bomb.rs
+++ b/cs2/src/state/bomb.rs
@@ -4,7 +4,10 @@ use anyhow::Context;
 use cs2_schema_generated::cs2::client::{
     C_BaseEntity,
     C_BasePlayerPawn,
+    C_CSPlayerPawn,
+    C_EconEntity,
     C_PlantedC4,
+    C_C4,
 };
 use nalgebra::Vector3;
 use obfstr::obfstr;
@@ -64,6 +67,19 @@ pub struct PlantedC4 {
 
     /// Current bomb defuser
     pub defuser: Option<BombDefuser>,
+}
+
+/// Information about the current bomb carrier
+#[derive(Debug, Clone)]
+pub struct BombCarrierInfo {
+    /// Entity ID of the player carrying the bomb
+    pub carrier_entity_id: Option<u32>,
+
+    /// Name of the player carrying the bomb
+    pub carrier_name: Option<String>,
+
+    /// Team ID of the bomb carrier (should be 2 for terrorists)
+    pub carrier_team_id: Option<u8>,
 }
 
 impl State for PlantedC4 {
@@ -179,6 +195,83 @@ impl State for PlantedC4 {
             position: Default::default(),
             state: PlantedC4State::NotPlanted,
         });
+    }
+
+    fn cache_type() -> StateCacheType {
+        StateCacheType::Volatile
+    }
+}
+
+impl State for BombCarrierInfo {
+    type Parameter = ();
+
+    fn create(states: &StateRegistry, _param: Self::Parameter) -> anyhow::Result<Self> {
+        let memory = states.resolve::<StateCS2Memory>(())?;
+        let entities = states.resolve::<StateEntityList>(())?;
+        let class_name_cache = states.resolve::<ClassNameCache>(())?;
+
+        // Find the C4 entity and its owner
+        for entity_identity in entities.entities().iter() {
+            let class_info = entity_identity.entity_class_info()?;
+            let class_name = class_name_cache.lookup(&class_info)?;
+
+            if !class_name.map(|name| name == "C_C4").unwrap_or(false) {
+                continue;
+            }
+
+            let c4_entity = entity_identity
+                .entity_ptr::<dyn C_EconEntity>()?
+                .value_reference(memory.view_arc())
+                .context("C4 entity nullptr")?
+                .cast::<dyn C_C4>();
+
+            let owner_handle = c4_entity.m_hOwnerEntity()?;
+            if !owner_handle.is_valid() {
+                continue;
+            }
+
+            let owner_entity = entities.entity_from_handle(&owner_handle);
+            if let Some(owner_identity) = owner_entity {
+                let owner_pawn = owner_identity
+                    .value_reference(memory.view_arc())
+                    .context("owner pawn nullptr")?
+                    .cast::<dyn C_CSPlayerPawn>();
+
+                let controller_handle = owner_pawn.m_hController()?;
+                let team_id = owner_pawn.m_iTeamNum()?;
+
+                let carrier_name = if controller_handle.is_valid() {
+                    entities
+                        .entity_from_handle(&controller_handle)
+                        .and_then(|controller| controller.value_reference(memory.view_arc()))
+                        .and_then(|controller_ref| {
+                            controller_ref
+                                .m_iszPlayerName()
+                                .ok()
+                                .and_then(|name_bytes| {
+                                    CStr::from_bytes_until_nul(&name_bytes)
+                                        .ok()
+                                        .map(|name| name.to_string_lossy().to_string())
+                                })
+                        })
+                } else {
+                    None
+                };
+
+                return Ok(Self {
+                    carrier_entity_id: Some(owner_handle.get_entity_index()),
+                    carrier_name,
+                    carrier_team_id: Some(team_id),
+                });
+            }
+        }
+
+        // No bomb carrier found
+        Ok(Self {
+            carrier_entity_id: None,
+            carrier_name: None,
+            carrier_team_id: None,
+        })
     }
 
     fn cache_type() -> StateCacheType {

--- a/cs2/src/state/player.rs
+++ b/cs2/src/state/player.rs
@@ -19,7 +19,6 @@ use cs2_schema_generated::cs2::client::{
     C_CSPlayerPawn,
     C_CSPlayerPawnBase,
     C_EconEntity,
-    C_C4,
 };
 use utils_state::{
     State,
@@ -32,9 +31,7 @@ use crate::{
         CBoneStateData,
         CModelStateEx,
     },
-    CEntityIdentityEx,
     CS2Model,
-    ClassNameCache,
     StateCS2Memory,
     StateEntityList,
     WeaponId,
@@ -161,6 +158,7 @@ impl State for StatePawnInfo {
             .value_reference(memory.view_arc());
         let weapon_type = if let Some(weapon) = weapon {
             weapon
+                .cast::<dyn C_EconEntity>()
                 .m_AttributeManager()?
                 .m_Item()?
                 .m_iItemDefinitionIndex()?
@@ -170,29 +168,13 @@ impl State for StatePawnInfo {
 
         let player_flashtime = player_pawn.m_flFlashBangTime()?;
 
-        let player_has_bomb = entities
-            .entities()
-            .iter()
-            .find_map(|entity| {
-                let cache = states.resolve::<ClassNameCache>(()).ok()?;
-                let class_info = entity.entity_class_info().ok()?;
-                let class_name = cache.lookup(&class_info).ok()??;
-
-                if class_name != "C_C4" {
-                    return None;
-                }
-
-                let owner_handle = entity
-                    .entity_ptr::<dyn C_EconEntity>()
-                    .ok()?
-                    .value_reference(memory.view_arc())?
-                    .cast::<dyn C_C4>()
-                    .m_hOwnerEntity()
-                    .ok()?;
-
-                Some(owner_handle.get_entity_index() == handle.get_entity_index())
-            })
-            .unwrap_or(false);
+        // Use cached bomb carrier state instead of iterating through all entities
+        let player_has_bomb = if let Ok(bomb_carrier) = states.resolve::<super::BombCarrierInfo>(())
+        {
+            bomb_carrier.carrier_entity_id == Some(handle.get_entity_index())
+        } else {
+            false
+        };
 
         Ok(Self {
             controller_entity_id: if controller_handle.is_valid() {

--- a/cs2/src/state/player.rs
+++ b/cs2/src/state/player.rs
@@ -19,6 +19,7 @@ use cs2_schema_generated::cs2::client::{
     C_CSPlayerPawn,
     C_CSPlayerPawnBase,
     C_EconEntity,
+    C_C4,
 };
 use utils_state::{
     State,
@@ -31,7 +32,9 @@ use crate::{
         CBoneStateData,
         CModelStateEx,
     },
+    CEntityIdentityEx,
     CS2Model,
+    ClassNameCache,
     StateCS2Memory,
     StateEntityList,
     WeaponId,
@@ -45,6 +48,7 @@ pub struct StatePawnInfo {
 
     pub player_health: i32,
     pub player_has_defuser: bool,
+    pub player_has_bomb: bool,
     pub player_name: Option<String>,
     pub weapon: WeaponId,
     pub player_flashtime: f32,
@@ -166,6 +170,30 @@ impl State for StatePawnInfo {
 
         let player_flashtime = player_pawn.m_flFlashBangTime()?;
 
+        let player_has_bomb = entities
+            .entities()
+            .iter()
+            .find_map(|entity| {
+                let cache = states.resolve::<ClassNameCache>(()).ok()?;
+                let class_info = entity.entity_class_info().ok()?;
+                let class_name = cache.lookup(&class_info).ok()??;
+
+                if class_name != "C_C4" {
+                    return None;
+                }
+
+                let owner_handle = entity
+                    .entity_ptr::<dyn C_EconEntity>()
+                    .ok()?
+                    .value_reference(memory.view_arc())?
+                    .cast::<dyn C_C4>()
+                    .m_hOwnerEntity()
+                    .ok()?;
+
+                Some(owner_handle.get_entity_index() == handle.get_entity_index())
+            })
+            .unwrap_or(false);
+
         Ok(Self {
             controller_entity_id: if controller_handle.is_valid() {
                 Some(controller_handle.get_entity_index())
@@ -178,6 +206,7 @@ impl State for StatePawnInfo {
 
             player_name,
             player_has_defuser,
+            player_has_bomb,
             player_health,
             weapon: WeaponId::from_id(weapon_type).unwrap_or(WeaponId::Unknown),
             player_flashtime,


### PR DESCRIPTION
This PR introduces long-requested bomb-related ESP improvements.  
An earlier PR #98  attempted to add these features but was never merged and is now outdated with many conflicts.  
I’ve reimplemented them in a clean and up-to-date way for easier review and integration.  

### ✨ New Features
- **Bomb Carrier ESP**  
  Displays the current bomb carrier’s position (Terrorist team) directly in the ESP overlay.  

### 📸 Preview
<img width="2560" height="1080" alt="Bomb Carrier ESP" src="https://github.com/user-attachments/assets/8ab31a70-40c1-42bd-8217-7a603a03057f" />  

---

These features significantly improve gameplay awareness and provide valuable tactical information.  
Looking forward to your feedback and hopefully merging this PR 🚀