### PR TITLE
Feature: Add bomb details opacity to settings dialog in web radar

### DIFF
--- a/radar/web/src/state/radar-settings.ts
+++ b/radar/web/src/state/radar-settings.ts
@@ -9,6 +9,7 @@ export type RadarSettingsState = {
 
     iconSize: number,
     displayBombDetails: boolean,
+    bombDetailsOpacity: number,
     showAllLayers: boolean,
 
     mapStyle: string,
@@ -31,6 +32,7 @@ export const kDefaultRadarSettings: RadarSettingsState = {
     dialogOpen: false,
     iconSize: 3.0,
     displayBombDetails: true,
+    bombDetailsOpacity: 1.0,
     showAllLayers: true,
 
     displayStatistics: false,

--- a/radar/web/src/ui/components/bomb/bomb-indicator.tsx
+++ b/radar/web/src/ui/components/bomb/bomb-indicator.tsx
@@ -1,6 +1,7 @@
 import { Box, Paper, Typography } from "@mui/material";
 import * as colors from "@mui/material/colors";
 import React from "react";
+import { useSelector } from "react-redux";
 import { PlantedC4State } from "../../../backend/definitions";
 import IconC4 from "./icon_c4.svg";
 import IconDefuse from "./icon_defuse.svg";
@@ -65,6 +66,8 @@ const formatTime = (time: number): string => {
 export default React.memo((props: { state: PlantedC4State }) => {
     const { state } = props;
 
+    const bombDetailsOpacity = useSelector((s: any) => (s["radar-settings"] ?? s.radarSettings ?? {}).bombDetailsOpacity ?? 1.0);
+
     let text, textColor;
     let Icon;
     switch (state.state) {
@@ -107,6 +110,7 @@ export default React.memo((props: { state: PlantedC4State }) => {
 
                 position: "relative",
                 overflow: "hidden",
+                opacity: bombDetailsOpacity,
             }}
         >
             <Box

--- a/radar/web/src/ui/pages/session/[id]/modal-settings.tsx
+++ b/radar/web/src/ui/pages/session/[id]/modal-settings.tsx
@@ -58,6 +58,7 @@ export default React.memo(() => {
 
                 <TabPanel index={1} value={currentTab}>
                     <SettingSlider target={"iconSize"} title={"Icon Size"} min={0.1} max={5.0} step={0.1} />
+                    <SettingSlider target={"bombDetailsOpacity"} title={"Bomb Details Opacity"} min={0.1} max={1.0} step={0.1} />
 
                     <SettingBoolean target="displayBombDetails" title="Display Bomb Details" />
                     <SettingBoolean target="showAllLayers" title="Display all levels" />


### PR DESCRIPTION
When the map is scaled down in the browser, bomb-related details can sit on top of the map and obscure that region, making it hard to see player movement and map activity underneath. By allowing opacity adjustments, users can make the overlay more transparent so the map remains visible while still retaining bomb information.
This PR adds a configurable opacity for the bomb details overlay in the radar UI, allowing users to tune readability versus visual prominence.

### Screenshot
<img width="451" height="312" alt="image" src="https://github.com/user-attachments/assets/218da923-424b-4b3f-9c87-1a3396f3144b" />

